### PR TITLE
DOC: Add repository config to get snapshot package of maven.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ ___
 ## Getting Started
 ___
 ### Gradle
+
+#### Repository
+
+```groovy
+repositories {
+    url "https://oss.sonatype.org/content/repositories/snapshots"   
+}
+```
+
+#### Dependency
+
 ```groovy
 dependencies {
     testImplementation "com.jam2in.arcus:arcus-test-container:0.0.1-SNAPSHOT"
@@ -15,6 +26,20 @@ dependencies {
 ```
 
 ### Maven
+
+#### Repository
+
+```xml
+<repository>
+    <id>snapshots-repo</id>
+    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    <releases><enabled>false</enabled></releases>
+    <snapshots><enabled>true</enabled></snapshots>
+</repository>
+```
+
+#### Dependency
+
 ```xml
 <dependency>
     <groupId>com.jam2in.arcus</groupId>


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- SNAPSHOT 패키지는 Maven Central Repository에 올라오지 않는다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- SNAPSHOT 패키지를 가져올 수 있는 Repository 설정을 문서에 추가합니다.
